### PR TITLE
made sorting title, album, and artist case insensitive

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -101,6 +101,9 @@
     }
   },
   "cli": {
-    "schematicCollections": ["@angular-eslint/schematics"]
+    "schematicCollections": [
+      "@angular-eslint/schematics"
+    ],
+    "analytics": false
   }
 }

--- a/src/app/playlist/playlist.component.ts
+++ b/src/app/playlist/playlist.component.ts
@@ -4,7 +4,7 @@ import { MatSort, Sort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { shuffle } from 'lodash-es';
-import { fromEvent, interval, Subject } from 'rxjs';
+import { Subject, fromEvent, interval } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import {
   DeletePlaylistDialogComponent,
@@ -57,11 +57,11 @@ type MatSortDirectionType = 'asc' | 'desc';
 
 function sortingDataAccessor(track: ITrackWFeatures, sortHeaderId: string): string | number {
   if (sortHeaderId === ESortableColumns.name) {
-    return track.track.name;
+    return track.track.name.toLocaleLowerCase();
   } else if (sortHeaderId === ESortableColumns.artist) {
-    return track.track.artists[0].name;
+    return track.track.artists[0].name.toLocaleLowerCase();
   } else if (sortHeaderId === ESortableColumns.album_name) {
-    return track.track.album.name;
+    return track.track.album.name.toLocaleLowerCase();
   } else if (sortHeaderId === ESortableColumns.release_date) {
     return getReleaseDate(track);
   } else if (sortHeaderId === ESortableColumns.duration_ms) {


### PR DESCRIPTION
fix(sorting function): Ensure sorting is case insensitive and foreign/accented letters and symbols are sorted.

Ensures sorting is case insensitive. Also now takes into consideration foreign and accented letters and symbols. The sorting would previously sort lowercase song titles, artists, and album titles to the bottom. Now lowercase titles are sorted alphabetically, insensitive to casing. Symbols and foreign/accented letters, although sorted correctly, were not purposefully accounted for; foreign titles, artists, and album names are now sorted based on the local language.

#41